### PR TITLE
faster downloading & local dev cacheing of models

### DIFF
--- a/flux/modules/conditioner.py
+++ b/flux/modules/conditioner.py
@@ -3,18 +3,18 @@ from transformers import CLIPTextModel, CLIPTokenizer, T5EncoderModel, T5Tokeniz
 
 
 class HFEmbedder(nn.Module):
-    def __init__(self, version: str, max_length: int, **hf_kwargs):
+    def __init__(self, version: str, max_length: int, is_clip: bool = False, **hf_kwargs):
         super().__init__()
-        self.is_clip = version.startswith("openai")
+        self.is_clip = is_clip
         self.max_length = max_length
         self.output_key = "pooler_output" if self.is_clip else "last_hidden_state"
 
         if self.is_clip:
-            self.tokenizer: CLIPTokenizer = CLIPTokenizer.from_pretrained(version, max_length=max_length)
-            self.hf_module: CLIPTextModel = CLIPTextModel.from_pretrained(version, **hf_kwargs)
+            self.tokenizer: CLIPTokenizer = CLIPTokenizer.from_pretrained(version + "/tokenizer", max_length=max_length)
+            self.hf_module: CLIPTextModel = CLIPTextModel.from_pretrained(version + "/model", **hf_kwargs)
         else:
-            self.tokenizer: T5Tokenizer = T5Tokenizer.from_pretrained(version, max_length=max_length)
-            self.hf_module: T5EncoderModel = T5EncoderModel.from_pretrained(version, **hf_kwargs)
+            self.tokenizer: T5Tokenizer = T5Tokenizer.from_pretrained(version + "/tokenizer", max_length=max_length)
+            self.hf_module: T5EncoderModel = T5EncoderModel.from_pretrained(version + "/model", **hf_kwargs)
 
         self.hf_module = self.hf_module.eval().requires_grad_(False)
 

--- a/flux/util.py
+++ b/flux/util.py
@@ -670,13 +670,13 @@ def load_flow_model(name: str, device: str | torch.device = "cuda", verbose: boo
     return model
 
 
-def load_t5(device: str | torch.device = "cuda", max_length: int = 512) -> HFEmbedder:
+def load_t5(device: str | torch.device = "cuda", max_length: int = 512, t5_path: str = "./models/t5") -> HFEmbedder:
     # max length 64, 128, 256 and 512 should work (if your sequence is short enough)
-    return HFEmbedder("google/t5-v1_1-xxl", max_length=max_length, torch_dtype=torch.bfloat16).to(device)
+    return HFEmbedder(t5_path, max_length=max_length, torch_dtype=torch.bfloat16).to(device)
 
 
-def load_clip(device: str | torch.device = "cuda") -> HFEmbedder:
-    return HFEmbedder("openai/clip-vit-large-patch14", max_length=77, torch_dtype=torch.bfloat16).to(device)
+def load_clip(device: str | torch.device = "cuda", clip_path: str = "./models/clip") -> HFEmbedder:
+    return HFEmbedder(clip_path, max_length=77, torch_dtype=torch.bfloat16, is_clip=True).to(device)
 
 
 def load_ae(name: str, device: str | torch.device = "cuda") -> AutoEncoder:

--- a/predict.py
+++ b/predict.py
@@ -22,11 +22,13 @@ from flux.util import ASPECT_RATIOS
 
 # Kontext model configuration
 KONTEXT_WEIGHTS_URL = "https://weights.replicate.delivery/default/black-forest-labs/kontext/release-candidate/kontext-dev.sft"
-KONTEXT_WEIGHTS_PATH = "/models/kontext/kontext-dev.sft"
-
-# Model weights URLs
+KONTEXT_WEIGHTS_PATH = "./models/kontext/kontext-dev.sft"
 AE_WEIGHTS_URL = "https://weights.replicate.delivery/default/black-forest-labs/FLUX.1-dev/safetensors/ae.safetensors"
-AE_WEIGHTS_PATH = "/models/flux-dev/ae.safetensors"
+AE_WEIGHTS_PATH = "./models/flux-dev/ae.safetensors"
+T5_WEIGHTS_URL = "https://weights.replicate.delivery/default/official-models/flux/t5/t5-v1_1-xxl.tar"
+T5_WEIGHTS_PATH = "./models/t5"
+CLIP_URL = "https://weights.replicate.delivery/default/official-models/flux/clip/clip-vit-large-patch14.tar"
+CLIP_PATH = "./models/clip"
 
 TORCH_COMPILE_CACHE = "./torch-compile-cache-flux-dev-kontext.bin"
 
@@ -45,10 +47,10 @@ class FluxDevKontextPredictor(BasePredictor):
         # Initialize models
         st = time.time()
         print("Loading t5...")
-        self.t5 = load_t5(self.device, max_length=512)
+        self.t5 = load_t5(self.device, max_length=512, t5_path=T5_WEIGHTS_PATH)
         print(f"Loaded t5 in {time.time() - st} seconds")
         st = time.time()
-        self.clip = load_clip(self.device)
+        self.clip = load_clip(self.device, clip_path=CLIP_PATH)
         print(f"Loaded clip in {time.time() - st} seconds")
         st = time.time()
         self.model = load_kontext_model(device=self.device)
@@ -217,6 +219,20 @@ def download_model_weights():
         print("Autoencoder weights downloaded successfully")
     else:
         print("Autoencoder weights already exist")
+
+    if not os.path.exists(T5_WEIGHTS_PATH):
+        print("T5 weights not found, downloading...")
+        download_weights(T5_WEIGHTS_URL, Path(T5_WEIGHTS_PATH))
+        print("T5 weights downloaded successfully")
+    else:
+        print("T5 weights already exist")
+        
+    if not os.path.exists(CLIP_PATH):
+        print("CLIP weights not found, downloading...")
+        download_weights(CLIP_URL, Path(CLIP_PATH))
+        print("CLIP weights downloaded successfully")
+    else:
+        print("CLIP weights already exist")
 
 
 def load_kontext_model(device: str | torch.device = "cuda"):


### PR DESCRIPTION
does a few things to speed up boot time and make local dev easier

- pulls bf16 t5 and clip model versions, much faster downloads instead of downloading from hf hub
- downloads models to ./models directory that'll be mapped to host machine, better for local development